### PR TITLE
rework deploy to use omnibus installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ Requirements
 ============
 * A Heat provider that supports the following:
   * OS::Nova::KeyPair
-  * Rackspace::Cloud::Server
   * OS::Heat::RandomString
-  * OS::Heat::ChefSolo
 * An OpenStack username, password, and tenant id.
 * [python-heatclient](https://github.com/openstack/python-heatclient)
 `>= v0.2.8`:
@@ -72,8 +70,7 @@ Use `heat output-show <OUTPUT NAME>` to get the value fo a specific output.
 
 * `private_key`: SSH private that can be used to login as root to the server.
 * `server_ip`: Public IP address of the cloud server
-* `gitlab_admin_user`: Login id for the admin user
-* `gitlab_admin_password`: Password for the `gitlab_admin_user` login
+* `gitlab_admin_password`: Password for the `root` login
 
 For multi-line values, the response will come in an escaped form. To get rid of
 the escapes, use `echo -e '<STRING>' > file.txt`. For vim users, a substitution
@@ -90,6 +87,8 @@ To access your GitLab deployment, take the IP of the GitLab server and plug
 it in your browser. By default it will redirect you to https and you'll get a
 warning since a self signed certificate is installed.
 
+Login as `root` using the password stored in the output `gitlab_admin_password`.
+
 #### Logging in via SSH
 The private key provided in the passwords section can be used to login as
 root via SSH.  We have an article on how to use these keys with [Mac OS X
@@ -98,59 +97,11 @@ as well as [Windows using
 PuTTY](http://www.rackspace.com/knowledge_center/article/logging-in-with-a-ssh-private-key-on-windows).
 
 #### Details of Your Setup
-This deployment was stood up using
-[chef-solo](http://docs.opscode.com/chef_solo.html). Once the deployment is
-up, chef will not run again, so it is safe to modify configurations.
+Gitlab is installed using the [Gitlab Omnibus installer](https://gitlab.com/gitlab-org/omnibus-gitlab)
 
-Mail delivery is set to be handled by [Postfix](http://www.postfix.org/). If
-you are a Managed Cloud customer, Postfix has been re-configured to work with
-[Mailgun](http://www.mailgun.com/).
+Full documentation is available in [the Gitlab Omnibus README file](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md).
 
-GitLab itself has been installed into '/srv/git/gitlab'.  GitLab itself is a
-rails application. GitLab also has it's own version of Ruby that has been
-installed. You will find both the ruby and gem binaries in '/srv/git/bin/'.
-We recommend that all management actions related to gems and other ruby
-packages be performed as the 'git' user.
-
-A system user named 'git' has been created with a home of /srv/git. This is
-the user used for all services associated directly with GitLab.
-
-[Ruby](https://www.ruby-lang.org/en/) has been compiled from source and can
-be found installed in '/srv/git'. By default, only the 'git' user will have
-'/srv/git' in it's $PATH. We recommend running all gem commands as the 'git'
-user to avoid any potential permission issues.
-
-[Redis](http://redis.io/) is installed and required for running GitLab. The
-configuration can be found in the '/etc/redis' directory.
-
-[Nginx](http://nginx.org/en/) is installed as the web server for this
-deployment. There are two sites configured, one to redirect all port 80
-traffic to port 443, and the other to manage connections to Unicorn. Both
-site configurations can be found in '/etc/nginx/sites-available' and are
-named 'gitlab' and 'http_redirect' respectively. Any changes to the site
-configurations will require a restart of the Nginx service.
-
-The self signed SSL certificate and private key used in can be found in
-'/etc/nginx/ssl/'. If you replace the key and cert with your own, please make
-sure to restart the nginx serice.
-
-[Unicorn](http://unicorn.bogomips.org/) is a Rack HTTP server installed to
-serve GitLab requests. All requests are proxied through Nginx. The unicorn
-configuration can be found in '/srv/git/gitlab/config/unicorn.rb'. Any
-changes will require a restart of unicorn. Unicorn is managed through the
-'gitlab' service, by restarting the gitlab service, it will restart both
-Unicorn and Sidekiq.
-
-[Sidekiq](http://sidekiq.org/) is running as a worker process.  Sidekiq works
-directly with the redis service installed. The configuration is located at
-'/srv/git/gitlab/config/initializers/4_sidekiq.rb'. This service is managed
-with the gitlab service like Unicorn.
-
-[MySQL](http://www.mysql.com/) is installed locally. The MySQL root password
-is provided in the passwords/secrets section of this deployment. We've added
-'/root/.my.cnf' to your system to make management of MySQL easier. This
-contains your root password as well in case you forget or lose your MySQL
-root password.
+* [How to start and stop gitlab components](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#starting-and-stopping)
 
 Contributing
 ============

--- a/gitlab.yaml
+++ b/gitlab.yaml
@@ -10,15 +10,9 @@ parameter_groups:
   - image
   - flavor
 
-- label: Gitlab Settings
-  parameters:
-  - gitlab_admin_user
-
 - label: rax-dev-params
   parameters:
   - server_hostname
-  - kitchen
-  - chef_version
 
 parameters:
 
@@ -41,11 +35,9 @@ parameters:
       Server image used for all servers that are created as a part of this
       deployment
     type: string
-    default: Ubuntu 14.04 LTS (Trusty Tahr) (PV)
+    default: Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
     constraints:
     - allowed_values:
-      - Ubuntu 12.04 LTS (Precise Pangolin) (PVHVM)
-      - Ubuntu 14.04 LTS (Trusty Tahr) (PV)
       - Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)
       description: Must be a supported operating system.
 
@@ -74,24 +66,6 @@ parameters:
         Must be a valid Rackspace Cloud Server flavor for the region you have
         selected to deploy into.
 
-  kitchen:
-    label: Kitchen
-    description: URL for the kitchen to use
-    type: string
-    default: https://github.com/rackspace-orchestration-templates/gitlab.git
-
-  chef_version:
-    label: Chef Version
-    description: Version of chef client to use
-    type: string
-    default: 11.12.8
-
-  gitlab_admin_user:
-    label: Gitlab Admin Username
-    description: User name for gitlab admin user
-    type: string
-    default: root
-
 resources:
 
   ssh_key:
@@ -106,32 +80,17 @@ resources:
       length: 32
       sequence: lettersdigits
 
-  gitlab_db_password:
-    type: OS::Heat::RandomString
+  wait_condition:
+    type: OS::Heat::SwiftSignal
     properties:
-      length: 32
-      sequence: lettersdigits
+      handle: { get_resource: wait_condition_handle }
+      timeout: 600
 
-  mysql_debian_password:
-    type: OS::Heat::RandomString
-    properties:
-      length: 32
-      sequence: lettersdigits
-
-  mysql_repl_password:
-    type: OS::Heat::RandomString
-    properties:
-      length: 32
-      sequence: lettersdigits
-
-  mysql_root_password:
-    type: OS::Heat::RandomString
-    properties:
-      length: 32
-      sequence: lettersdigits
+  wait_condition_handle:
+    type: OS::Heat::SwiftSignalHandle
 
   gitlab_server:
-    type: "Rackspace::Cloud::Server"
+    type: "OS::Nova::Server"
     properties:
       name: { get_param: server_hostname }
       flavor: { get_param: flavor }
@@ -139,46 +98,77 @@ resources:
       key_name: { get_resource: ssh_key }
       metadata:
         rax-heat: { get_param: "OS::stack_id" }
+      config_drive: "true"
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #cloud-config
+            package_update: true
+            packages:
+              - build-essential
+              - curl
+              - openssh-server
+              - postfix
+              - python-pip
+            write_files:
+              - path: /root/gitlab.rb
+                permissions: '0600'
+                content: |
+                  external_url "https://%server_hostname%"
+                  gitlab_rails['initial_root_password'] = "%gitlab_admin_password%"
+                  nginx['custom_nginx_config'] = "include /var/opt/gitlab/nginx/conf/gitlab-http-redirect.conf;"
+              - path: /root/gitlab-http-redirect.conf
+                permissions: '0655'
+                content: |
+                  server {
+                    listen 80;
+                    return 301 https://$host$request_uri;
+                  }
+              - path: /root/setup/install_gitlab.sh
+                permissions: '0500'
+                content: |
+                  #!/bin/bash -ex
 
-  gitlab_setup:
-    type: "OS::Heat::ChefSolo"
-    depends_on: gitlab_server
-    properties:
-      username: root
-      private_key: { get_attr: [ssh_key, private_key] }
-      host: { get_attr: [gitlab_server, accessIPv4] }
-      kitchen: { get_param: kitchen }
-      chef_version: { get_param: chef_version }
-      node:
-        build-essential:
-          compile_time: true
-        gitlab:
-          admin_password: { get_attr: [gitlab_admin_password, value] }
-          admin_user: { get_param: gitlab_admin_user }
-          database:
-            password: { get_attr: [gitlab_db_password, value] }
-          generate_self_signed_cert: true
-          https: true
-          self_signed_cert: true
-        mysql:
-          bind_address: 127.0.0.1
-          server_debian_password: { get_attr: [mysql_debian_password, value] }
-          server_repl_password: { get_attr: [mysql_repl_password, value] }
-          server_root_password: { get_attr: [mysql_root_password, value] }
-        redisio:
-          servers:
-            - address: 127.0.0.1
-              port: 6379
-        run_list:
-          - recipe[apt]
-          - recipe[build-essential]
-          - recipe[mysql::server]
-          - recipe[dotmy-cnf]
-          - recipe[postfix::server]
-          - recipe[rax-gitlab::default]
-          - recipe[rax-gitlab::firewall]
-          - recipe[gitlab-http-redirect]
+                  error() {
+                    echo "ERROR: exiting at line $1"
+                    python -c 'import json,requests;requests.put("%wc_notify%",data=json.dumps({"status":"FAILURE","data":open("/var/log/cloud-init-output.log").read()}))'
+                    exit "${3:-1}"
+                  }
 
+                  trap 'error ${LINENO}' ERR
+
+                  pip install requests
+
+                  mkdir /root/working
+                  cd /root/working
+
+                  wget --progress=dot:giga 'https://downloads-packages.s3.amazonaws.com/ubuntu-14.04/gitlab_%version%-omnibus-1_amd64.deb'
+                  dpkg -i gitlab_%version%-omnibus-1_amd64.deb
+                  mv /etc/gitlab/gitlab.rb /etc/gitlab/gitlab.rb.original
+                  mv /root/gitlab.rb /etc/gitlab/gitlab.rb
+                  mkdir --mode=0750 /etc/gitlab/ssl
+                  openssl req \
+                  -subj '/CN=%server_hostname%/O=My Company Name LTD./C=US' \
+                  -new -newkey rsa:2048 -days 3650 -sha256 -nodes -x509   \
+                  -keyout /etc/gitlab/ssl/%server_hostname%.key           \
+                  -out /etc/gitlab/ssl/%server_hostname%.crt
+                  mkdir -p /var/opt/gitlab/nginx/conf
+                  mv /root/gitlab-http-redirect.conf /var/opt/gitlab/nginx/conf
+                  /usr/bin/gitlab-ctl reconfigure
+                  ufw allow 22
+                  ufw allow 80
+                  ufw allow 443
+                  ufw --force enable
+
+                  python -c 'import json,requests;requests.put("%wc_notify%",data=json.dumps({"status":"SUCCESS","data":open("/var/log/cloud-init-output.log").read()}))'
+            runcmd:
+              - /root/setup/install_gitlab.sh
+          params:
+              '%gitlab_admin_password%': { get_attr: [gitlab_admin_password, value] }
+              '%server_hostname%': { get_param: server_hostname }
+              '%wc_notify%': { get_attr: ['wait_condition_handle', 'endpoint'] }
+              '%version%': 7.8.1
 
 outputs:
   private_key:
@@ -189,10 +179,10 @@ outputs:
     description: Server IP
     value: { get_attr: [gitlab_server, accessIPv4] }
 
-  gitlab_admin_user:
-    description: GitLab User
-    value: { get_param: gitlab_admin_user }
-
   gitlab_admin_password:
     description: GitLab Password
     value: { get_attr: [gitlab_admin_password, value] }
+
+  server_data:
+    value: { get_attr: [ wait_condition, data ] }
+    description: Data from wait condition to report script status

--- a/rackspace.yaml
+++ b/rackspace.yaml
@@ -23,6 +23,9 @@ instructions: |
   it in your browser. By default it will redirect you to https and you'll get a
   warning since a self signed certificate is installed.
 
+  Login with account name `root` using the password from the
+  `gitlab_admin_password` output
+
   #### Logging in via SSH
   The private key provided in the passwords section can be used to login as
   root via SSH.  We have an article on how to use these keys with [Mac OS X
@@ -31,57 +34,11 @@ instructions: |
   PuTTY](http://www.rackspace.com/knowledge_center/article/logging-in-with-a-ssh-private-key-on-windows).
 
   #### Details of Your Setup
-  This deployment was stood up using
-  [chef-solo](http://docs.opscode.com/chef_solo.html). Once the deployment is
-  up, chef will not run again, so it is safe to modify configurations.
 
-  Mail delivery is set to be handled by [Postfix](http://www.postfix.org/). If
-  you are a Managed Cloud customer, Postfix has been re-configured to work with
-  [Mailgun](http://www.mailgun.com/).
+  Gitlab is installed using the [Gitlab Omnibus installer](https://gitlab.com/gitlab-org/omnibus-gitlab)
 
-  GitLab itself has been installed into '/srv/git/gitlab'.  GitLab itself is a
-  rails application. GitLab also has it's own version of Ruby that has been
-  installed. You will find both the ruby and gem binaries in '/srv/git/bin/'.
-  We recommend that all management actions related to gems and other ruby
-  packages be performed as the 'git' user.
+  Full documentation is available in [the Gitlab Omnibus README file](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md).
 
-  A system user named 'git' has been created with a home of /srv/git. This is
-  the user used for all services associated directly with GitLab.
+  * [How to start and stop gitlab components](https://gitlab.com/gitlab-org/omnibus-gitlab/blob/master/README.md#starting-and-stopping)
 
-  [Ruby](https://www.ruby-lang.org/en/) has been compiled from source and can
-  be found installed in '/srv/git'. By default, only the 'git' user will have
-  '/srv/git' in it's $PATH. We recommend running all gem commands as the 'git'
-  user to avoid any potential permission issues.
-
-  [Redis](http://redis.io/) is installed and required for running GitLab. The
-  configuration can be found in the '/etc/redis' directory.
-
-  [Nginx](http://nginx.org/en/) is installed as the web server for this
-  deployment. There are two sites configured, one to redirect all port 80
-  traffic to port 443, and the other to manage connections to Unicorn. Both
-  site configurations can be found in '/etc/nginx/sites-available' and are
-  named 'gitlab' and 'http_redirect' respectively. Any changes to the site
-  configurations will require a restart of the Nginx service.
-
-  The self signed SSL certificate and private key used in can be found in
-  '/etc/nginx/ssl/'. If you replace the key and cert with your own, please make
-  sure to restart the nginx serice.
-
-  [Unicorn](http://unicorn.bogomips.org/) is a Rack HTTP server installed to
-  serve GitLab requests. All requests are proxied through Nginx. The unicorn
-  configuration can be found in '/srv/git/gitlab/config/unicorn.rb'. Any
-  changes will require a restart of unicorn. Unicorn is managed through the
-  'gitlab' service, by restarting the gitlab service, it will restart both
-  Unicorn and Sidekiq.
-
-  [Sidekiq](http://sidekiq.org/) is running as a worker process.  Sidekiq works
-  directly with the redis service installed. The configuration is located at
-  '/srv/git/gitlab/config/initializers/4_sidekiq.rb'. This service is managed
-  with the gitlab service like Unicorn.
-
-  [MySQL](http://www.mysql.com/) is installed locally. The MySQL root password
-  is provided in the passwords/secrets section of this deployment. We've added
-  '/root/.my.cnf' to your system to make management of MySQL easier. This
-  contains your root password as well in case you forget or lose your MySQL
-  root password.
-user-input-required: true
+user-input-required: false

--- a/test/fabric/gitlab.py
+++ b/test/fabric/gitlab.py
@@ -1,31 +1,35 @@
-from fabric.api import env, task
+import re
+import requests
+from fabric.api import env, task, run, hide
 from envassert import detect, file, group, package, port, process, service, \
     user
 from hot.utils.test import get_artifacts
 
 
+def gitlab_is_responding():
+    r = requests.get("https://{}/users/sign_in".format(env.host), verify=False)
+    if r.status_code == 200 and re.search("GitLab Community Edition", r.text):
+        return True
+    else:
+        print "Oops! gitlab return status was {}.".format(r.status_code)
+        return False
+
 @task
 def check():
     env.platform_family = detect.detect()
 
-    assert package.installed("nginx"), "package nginx is not installed"
-    assert package.installed("mysql-server-5.5"), "package mysql-server-5.5 is not installed"
-    assert file.exists(
-        "/srv/git/gitlab/vendor/bundle/ruby/1.9.1/bin/unicorn_rails"), "unicorn is not configured"
-    assert file.exists("/srv/git/bin/ruby"), "ruby is not installed"
-    assert port.is_listening(80), "port 80 is not listening"
-    assert port.is_listening(443), "port 443 is not listening"
-    assert port.is_listening(3306), "port 3306 is not listening"
-    assert port.is_listening(6379), "port 6379 is not listening"
+    assert port.is_listening(443), "port 443 (nginx) is not listening"
+    assert port.is_listening(8080), "port 8080 (gitlab) is not listening"
+    assert port.is_listening(22), "port 22 (ssh) is not listening"
     assert user.exists("git"), "there is no git user"
     assert group.is_exists("git"), "there is no git group"
     assert user.is_belonging_group("git", "git"), "user git is not in the git group"
     assert process.is_up("nginx"), "nginx is not running"
-    assert process.is_up("mysqld"), "mysqld is not running"
+    assert process.is_up("postgres"), "postgres is not running"
     assert process.is_up("redis-server"), "redis-server is not running"
     assert service.is_enabled("nginx"), "service nginx is not enabled"
-    assert service.is_enabled("mysqld"), "service mysqld is not enabled"
     assert service.is_enabled("gitlab"), "service gitlab is not enabled"
+    assert gitlab_is_responding(), "gitlab did not respond as expected"
 
 
 @task

--- a/tests.yaml
+++ b/tests.yaml
@@ -22,29 +22,3 @@ test-cases:
             disable_known_hosts: True
             use_ssh_config: True
             fabfile: test/fabric/gitlab.py # Path to envassert test
-
-- name: Standard Instance, Ubuntu 12.04, non-default user
-  create:
-    parameters:
-      flavor: 2GB Standard Instance
-      image: Ubuntu 12.04 LTS (Precise Pangolin) (PVHVM)
-      gitlab_admin_user: admin
-    timeout: 45
-  resource_tests:
-    ssh_private_key: { get_output: private_key }
-    ssh_key_file: tmp/private_key
-    tests:
-    - gitlab:
-        fabric:
-          env:
-            user: root
-            key_filename: tmp/private_key
-            hosts: { get_output: server_ip }
-            tasks:
-              - artifacts
-              - check
-            abort_on_prompts: True
-            connection_attempts: 3
-            disable_known_hosts: True
-            use_ssh_config: True
-            fabfile: test/fabric/gitlab.py


### PR DESCRIPTION
ditching the chef-solo provider and using only cloud-init, a shell script, and some inline Python.

This is considerably faster, completing in 3-5 minutes, versus the 20-45 minutes the current version takes.

I feel this will be easier to maintain. We can add tests to check for new versions of Gitlab, or roll that logic into a Python script we use in the deploy.

Thoughts?