### PR TITLE
Change backup frequency and location

### DIFF
--- a/gitlab.yaml
+++ b/gitlab.yaml
@@ -167,7 +167,7 @@ resources:
       host_ip_address: { get_attr: [gitlab_server, accessIPv4] }
       BackupConfigurationName:
         str_replace:
-          template: stack Weekly Backup
+          template: stack Daily Backup
           params:
             stack: { get_param: "OS::stack_name" }
       Inclusions:

--- a/gitlab.yaml
+++ b/gitlab.yaml
@@ -171,9 +171,7 @@ resources:
           params:
             stack: { get_param: "OS::stack_name" }
       Inclusions:
-      - FilePath: "/var/spool/holland"
-        FileItemType: "Folder"
-      - FilePath: "/var/www/"
+      - FilePath: "/var/opt/gitlab/backups/"
         FileItemType: "Folder"
       NotifyFailure: true
       NotifyRecipients: { get_param: gitlab_email }
@@ -182,8 +180,8 @@ resources:
       StartTimeHour: 1
       StartTimeMinute: 0
       HourInterval: null
-      DayOfWeekId: 0
-      Frequency: "Weekly"
+      DayOfWeekId: null
+      Frequency: "Daily"
       VersionRetention: 30
 outputs:
   ssh_private_key:


### PR DESCRIPTION
Gitlab does not use /var/spoo/holland or /var/www from our templates, so there is no reason to bacl these up.. You already setup a cronjob to run the backup creator daily, so I've updated the template to match - stack 4b310672-7698-45c0-b0c2-12da5b3e192f built for test


RC version incoming once tested